### PR TITLE
Resolve project name conflicts.

### DIFF
--- a/src/SlnMerge.cs
+++ b/src/SlnMerge.cs
@@ -274,6 +274,26 @@ namespace SlnMerge
             {
                 if (!ctx.MergedSolutionFile.Projects.ContainsKey(project.Key))
                 {
+                    // If a solution contains a project that has same name, resolve conflict by resolution strategy.
+                    if (ctx.MergedSolutionFile.Projects.Any(x => x.Value.Name == project.Value.Name))
+                    {
+                        if (ctx.Settings.ProjectConflictResolution == ProjectConflictResolution.PreserveUnity)
+                        {
+                            // Ignore Overlay's project
+                            continue;
+                        }
+                        else if (ctx.Settings.ProjectConflictResolution == ProjectConflictResolution.PreserveOverlay)
+                        {
+                            // Remove Unity generated project
+                            var duplicatedProject = ctx.MergedSolutionFile.Projects.First(x => x.Value.Name == project.Value.Name);
+                            ctx.MergedSolutionFile.Projects.Remove(duplicatedProject.Key);
+                        }
+                        else
+                        {
+                            // Preserve all projects
+                        }
+                    }
+
                     if (!project.Value.IsFolder)
                     {
                         var overlayProjectPathAbsolute = NormalizePath(Path.Combine(Path.GetDirectoryName(ctx.OverlaySolutionFile.Path), project.Value.Path));

--- a/src/SlnMerge.cs
+++ b/src/SlnMerge.cs
@@ -129,6 +129,7 @@ namespace SlnMerge
     {
         public bool Disabled { get; set; }
         public NestedProject[] NestedProjects { get; set; }
+        public ProjectConflictResolution ProjectConflictResolution { get; set; }
 
         public string MergeTargetSolution { get; set; }
 
@@ -151,6 +152,22 @@ namespace SlnMerge
                 return (SlnMergeSettings)new XmlSerializer(typeof(SlnMergeSettings)).Deserialize(stream);
             }
         }
+    }
+
+    public enum ProjectConflictResolution
+    {
+        /// <summary>
+        /// Preseve All projects.
+        /// </summary>
+        PreserveAll,
+        /// <summary>
+        /// Preserve Unity generated project.
+        /// </summary>
+        PreserveUnity,
+        /// <summary>
+        /// Preserve Overlay original project.
+        /// </summary>
+        PreserveOverlay,
     }
 
     public static class SlnMerge
@@ -218,33 +235,51 @@ namespace SlnMerge
             return true;
         }
 
+        private class SlnMergeMergeContext
+        {
+            public SolutionFile SolutionFile { get; }
+            public SolutionFile OverlaySolutionFile { get; }
+            public SolutionFile MergedSolutionFile { get; }
+            public SlnMergeSettings Settings { get; }
+            public ISlnMergeLogger Logger { get; }
+
+            public SlnMergeMergeContext(SolutionFile solutionFile, SolutionFile overlaySolutionFile, SolutionFile mergedSolutionFile, SlnMergeSettings settings, ISlnMergeLogger logger)
+            {
+                SolutionFile = solutionFile;
+                OverlaySolutionFile = overlaySolutionFile;
+                MergedSolutionFile = mergedSolutionFile;
+                Settings = settings;
+                Logger = logger;
+            }
+        }
+
         public static SolutionFile Merge(SolutionFile solutionFile, SolutionFile overlaySolutionFile, SlnMergeSettings settings, ISlnMergeLogger logger)
         {
             logger.Debug($"Merge solution: Base={solutionFile.Path}; Overlay={overlaySolutionFile.Path}");
 
-            var mergedSolutionFile = solutionFile.Clone();
+            var ctx = new SlnMergeMergeContext(solutionFile, overlaySolutionFile, solutionFile.Clone(), settings, logger);
 
-            MergeProjects(mergedSolutionFile, overlaySolutionFile, settings, logger);
+            MergeProjects(ctx);
 
-            MergeGlobalSections(mergedSolutionFile, overlaySolutionFile, settings, logger);
+            MergeGlobalSections(ctx);
 
-            ModifySolutionFolders(mergedSolutionFile, settings, logger);
+            ModifySolutionFolders(ctx);
 
-            return mergedSolutionFile;
+            return ctx.MergedSolutionFile;
         }
 
-        private static void MergeProjects(SolutionFile solutionFile, SolutionFile overlaySolutionFile, SlnMergeSettings settings, ISlnMergeLogger logger)
+        private static void MergeProjects(SlnMergeMergeContext ctx)
         {
-            foreach (var project in overlaySolutionFile.Projects)
+            foreach (var project in ctx.OverlaySolutionFile.Projects)
             {
-                if (!solutionFile.Projects.ContainsKey(project.Key))
+                if (!ctx.MergedSolutionFile.Projects.ContainsKey(project.Key))
                 {
                     if (!project.Value.IsFolder)
                     {
-                        var overlayProjectPathAbsolute = NormalizePath(Path.Combine(Path.GetDirectoryName(overlaySolutionFile.Path), project.Value.Path));
-                        project.Value.Path = MakeRelative(solutionFile.Path, overlayProjectPathAbsolute);
+                        var overlayProjectPathAbsolute = NormalizePath(Path.Combine(Path.GetDirectoryName(ctx.OverlaySolutionFile.Path), project.Value.Path));
+                        project.Value.Path = MakeRelative(ctx.MergedSolutionFile.Path, overlayProjectPathAbsolute);
                     }
-                    solutionFile.Projects.Add(project.Key, project.Value);
+                    ctx.MergedSolutionFile.Projects.Add(project.Key, project.Value);
                 }
                 else
                 {
@@ -253,11 +288,11 @@ namespace SlnMerge
             }
         }
 
-        private static void MergeGlobalSections(SolutionFile solutionFile, SolutionFile overlaySolutionFile, SlnMergeSettings settings, ISlnMergeLogger logger)
+        private static void MergeGlobalSections(SlnMergeMergeContext ctx)
         {
-            foreach (var sectionKeyValue in overlaySolutionFile.Global.Sections)
+            foreach (var sectionKeyValue in ctx.OverlaySolutionFile.Global.Sections)
             {
-                if (solutionFile.Global.Sections.TryGetValue(sectionKeyValue.Key, out var targetSection))
+                if (ctx.MergedSolutionFile.Global.Sections.TryGetValue(sectionKeyValue.Key, out var targetSection))
                 {
                     foreach (var keyValue in sectionKeyValue.Value.Values)
                     {
@@ -267,28 +302,28 @@ namespace SlnMerge
                 }
                 else
                 {
-                    solutionFile.Global.Sections.Add(sectionKeyValue.Key, sectionKeyValue.Value);
+                    ctx.MergedSolutionFile.Global.Sections.Add(sectionKeyValue.Key, sectionKeyValue.Value);
                 }
             }
         }
 
-        private static void ModifySolutionFolders(SolutionFile solutionFile, SlnMergeSettings settings, ISlnMergeLogger logger)
+        private static void ModifySolutionFolders(SlnMergeMergeContext ctx)
         {
-            if (settings.NestedProjects == null || settings.NestedProjects.Length == 0) return;
+            if (ctx.Settings.NestedProjects == null || ctx.Settings.NestedProjects.Length == 0) return;
 
             // Build a solution folder tree.
-            var solutionTree = BuildSolutionFlatTree(solutionFile);
+            var solutionTree = BuildSolutionFlatTree(ctx.MergedSolutionFile);
 
             // Create a NestedProject section in the solution if it does not exist.
-            if (!solutionFile.Global.Sections.TryGetValue(("NestedProjects", "preSolution"), out var section))
+            if (!ctx.MergedSolutionFile.Global.Sections.TryGetValue(("NestedProjects", "preSolution"), out var section))
             {
-                section = new SolutionGlobalSection(solutionFile.Global, "NestedProjects", "preSolution");
-                solutionFile.Global.Sections.Add((section.Category, section.Value), section);
+                section = new SolutionGlobalSection(ctx.MergedSolutionFile.Global, "NestedProjects", "preSolution");
+                ctx.MergedSolutionFile.Global.Sections.Add((section.Category, section.Value), section);
             }
 
             // Prepare to add nested projects.
             var nestedProjects = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-            foreach (var nestedProject in settings.NestedProjects)
+            foreach (var nestedProject in ctx.Settings.NestedProjects)
             {
                 var nestedProjectGuid = default(string);
                 var nestedProjectFolderGuid = default(string);
@@ -302,7 +337,7 @@ namespace SlnMerge
                 else
                 {
                     // by Name
-                    var proj = solutionFile.Projects.Values.FirstOrDefault(x => x.Name == nestedProject.ProjectName);
+                    var proj = ctx.MergedSolutionFile.Projects.Values.FirstOrDefault(x => x.Name == nestedProject.ProjectName);
                     if (proj != null)
                     {
                         nestedProjectGuid = proj.Guid;
@@ -346,13 +381,13 @@ namespace SlnMerge
                             else
                             {
                                 // Create a new solution folder.
-                                var newFolder = new SolutionProject(solutionFile,
+                                var newFolder = new SolutionProject(ctx.MergedSolutionFile,
                                     typeGuid: GuidProjectTypeFolder,
                                     guid: Guid.NewGuid().ToString("B").ToUpper(),
                                     name: pathParts[i],
                                     path: pathParts[i]
                                 );
-                                solutionFile.Projects.Add(newFolder.Guid, newFolder);
+                                ctx.MergedSolutionFile.Projects.Add(newFolder.Guid, newFolder);
 
                                 // If the solution folder has a parent folder, add the created folder as a child immediately.
                                 if (!string.IsNullOrEmpty(parentPath))
@@ -361,7 +396,7 @@ namespace SlnMerge
                                 }
 
                                 // Rebuild the solution tree.
-                                solutionTree = BuildSolutionFlatTree(solutionFile);
+                                solutionTree = BuildSolutionFlatTree(ctx.MergedSolutionFile);
 
                                 nestedProjectFolderGuid = newFolder.Guid;
                             }
@@ -378,11 +413,11 @@ namespace SlnMerge
                 {
                     throw new Exception($"Solution Folder '{nestedProject.FolderGuid}' (GUID) does not exists in the solution.");
                 }
-                if (!solutionFile.Projects.ContainsKey(nestedProjectGuid))
+                if (!ctx.MergedSolutionFile.Projects.ContainsKey(nestedProjectGuid))
                 {
                     throw new Exception($"Project '{nestedProject.FolderGuid}' (GUID) does not exists in the solution.");
                 }
-                if (!solutionFile.Projects.ContainsKey(nestedProjectFolderGuid))
+                if (!ctx.MergedSolutionFile.Projects.ContainsKey(nestedProjectFolderGuid))
                 {
                     throw new Exception($"Solution Folder '{nestedProject.FolderGuid}' (GUID) does not exists in the solution.");
                 }

--- a/test/SlnMerge.Tests/SlnMergeTest.cs
+++ b/test/SlnMerge.Tests/SlnMergeTest.cs
@@ -382,6 +382,415 @@ Global
 EndGlobal
 ".Trim(), content.Trim());
         }
+
+        [Fact]
+        public void TestMerge_SameName_PreserveAll()
+        {
+            var baseSln = SolutionFile.Parse(@"C:\Path\To\Nantoka\Nantoka.Unity\Nantoka.Unity.sln", @"
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 16
+Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""Assembly-CSharp"", ""Assembly-CSharp.csproj"", ""{1E7138DC-D3E2-51A8-4059-67524470B2E7}""
+EndProject
+Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""Assembly-CSharp-Editor"", ""Assembly-CSharp-Editor.csproj"", ""{A94A546A-4413-A73D-F517-3C1A7CCFE662}""
+EndProject
+Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""Nantoka.Shared"", ""Nantoka.Shared.csproj"", ""{CC600BF6-290F-4CF1-A92D-33B3A2B2BB6E}""
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{1E7138DC-D3E2-51A8-4059-67524470B2E7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1E7138DC-D3E2-51A8-4059-67524470B2E7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1E7138DC-D3E2-51A8-4059-67524470B2E7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1E7138DC-D3E2-51A8-4059-67524470B2E7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A94A546A-4413-A73D-F517-3C1A7CCFE662}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A94A546A-4413-A73D-F517-3C1A7CCFE662}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A94A546A-4413-A73D-F517-3C1A7CCFE662}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A94A546A-4413-A73D-F517-3C1A7CCFE662}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CC600BF6-290F-4CF1-A92D-33B3A2B2BB6E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CC600BF6-290F-4CF1-A92D-33B3A2B2BB6E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CC600BF6-290F-4CF1-A92D-33B3A2B2BB6E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CC600BF6-290F-4CF1-A92D-33B3A2B2BB6E}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(MonoDevelopProperties) = preSolution
+		StartupItem = Assembly-CSharp.csproj
+	EndGlobalSection
+EndGlobal
+".Trim());
+            var overlaySln = SolutionFile.Parse(@"C:\Path\To\Nantoka\Nantoka.Server\Nantoka.Server.sln", @"
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29509.3
+MinimumVisualStudioVersion = 10.0.40219.1
+Project(""{9A19103F-16F7-4668-BE54-9A1E7A4F7556}"") = ""Nantoka.Server"", ""Nantoka.Server\Nantoka.Server.csproj"", ""{053476FC-B8B2-4A14-AED2-3733DFD5DFC3}""
+EndProject
+Project(""{9A19103F-16F7-4668-BE54-9A1E7A4F7556}"") = ""Nantoka.Shared"", ""Nantoka.Shared\Nantoka.Shared.csproj"", ""{EC057CB9-6687-4425-82D8-A31A4EE9E4A2}""
+EndProject
+Project(""{2150E333-8FDC-42A3-9474-1A3956D46DE8}"") = ""Project Settings"", ""Project Settings"", ""{34006C71-946B-49BF-BBCB-BB091E5A3AE7}""
+	ProjectSection(SolutionItems) = preProject
+		.gitignore = .gitignore
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{053476FC-B8B2-4A14-AED2-3733DFD5DFC3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{053476FC-B8B2-4A14-AED2-3733DFD5DFC3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{053476FC-B8B2-4A14-AED2-3733DFD5DFC3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{053476FC-B8B2-4A14-AED2-3733DFD5DFC3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EC057CB9-6687-4425-82D8-A31A4EE9E4A2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EC057CB9-6687-4425-82D8-A31A4EE9E4A2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EC057CB9-6687-4425-82D8-A31A4EE9E4A2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EC057CB9-6687-4425-82D8-A31A4EE9E4A2}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {30D3EFC0-A5F4-4446-B14E-1C2C1740AA87}
+	EndGlobalSection
+EndGlobal
+".Trim());
+
+            var mergedSolutionFile = SlnMerge.Merge(baseSln, overlaySln, new SlnMergeSettings() { ProjectConflictResolution = ProjectConflictResolution.PreserveAll }, SlnMergeNullLogger.Instance);
+            var content = mergedSolutionFile.ToFileContent();
+            Assert.Equal(@"
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 16
+Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""Assembly-CSharp"", ""Assembly-CSharp.csproj"", ""{1E7138DC-D3E2-51A8-4059-67524470B2E7}""
+EndProject
+Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""Assembly-CSharp-Editor"", ""Assembly-CSharp-Editor.csproj"", ""{A94A546A-4413-A73D-F517-3C1A7CCFE662}""
+EndProject
+Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""Nantoka.Shared"", ""Nantoka.Shared.csproj"", ""{CC600BF6-290F-4CF1-A92D-33B3A2B2BB6E}""
+EndProject
+Project(""{9A19103F-16F7-4668-BE54-9A1E7A4F7556}"") = ""Nantoka.Server"", ""..\Nantoka.Server\Nantoka.Server\Nantoka.Server.csproj"", ""{053476FC-B8B2-4A14-AED2-3733DFD5DFC3}""
+EndProject
+Project(""{9A19103F-16F7-4668-BE54-9A1E7A4F7556}"") = ""Nantoka.Shared"", ""..\Nantoka.Server\Nantoka.Shared\Nantoka.Shared.csproj"", ""{EC057CB9-6687-4425-82D8-A31A4EE9E4A2}""
+EndProject
+Project(""{2150E333-8FDC-42A3-9474-1A3956D46DE8}"") = ""Project Settings"", ""Project Settings"", ""{34006C71-946B-49BF-BBCB-BB091E5A3AE7}""
+	ProjectSection(SolutionItems) = preProject
+		.gitignore = .gitignore
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{1E7138DC-D3E2-51A8-4059-67524470B2E7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1E7138DC-D3E2-51A8-4059-67524470B2E7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1E7138DC-D3E2-51A8-4059-67524470B2E7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1E7138DC-D3E2-51A8-4059-67524470B2E7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A94A546A-4413-A73D-F517-3C1A7CCFE662}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A94A546A-4413-A73D-F517-3C1A7CCFE662}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A94A546A-4413-A73D-F517-3C1A7CCFE662}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A94A546A-4413-A73D-F517-3C1A7CCFE662}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CC600BF6-290F-4CF1-A92D-33B3A2B2BB6E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CC600BF6-290F-4CF1-A92D-33B3A2B2BB6E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CC600BF6-290F-4CF1-A92D-33B3A2B2BB6E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CC600BF6-290F-4CF1-A92D-33B3A2B2BB6E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{053476FC-B8B2-4A14-AED2-3733DFD5DFC3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{053476FC-B8B2-4A14-AED2-3733DFD5DFC3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{053476FC-B8B2-4A14-AED2-3733DFD5DFC3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{053476FC-B8B2-4A14-AED2-3733DFD5DFC3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EC057CB9-6687-4425-82D8-A31A4EE9E4A2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EC057CB9-6687-4425-82D8-A31A4EE9E4A2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EC057CB9-6687-4425-82D8-A31A4EE9E4A2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EC057CB9-6687-4425-82D8-A31A4EE9E4A2}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(MonoDevelopProperties) = preSolution
+		StartupItem = Assembly-CSharp.csproj
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {30D3EFC0-A5F4-4446-B14E-1C2C1740AA87}
+	EndGlobalSection
+EndGlobal
+".Trim(), content.Trim());
+        }
+
+        [Fact]
+        public void TestMerge_SameName_PreserveUnity()
+        {
+            var baseSln = SolutionFile.Parse(@"C:\Path\To\Nantoka\Nantoka.Unity\Nantoka.Unity.sln", @"
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 16
+Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""Assembly-CSharp"", ""Assembly-CSharp.csproj"", ""{1E7138DC-D3E2-51A8-4059-67524470B2E7}""
+EndProject
+Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""Assembly-CSharp-Editor"", ""Assembly-CSharp-Editor.csproj"", ""{A94A546A-4413-A73D-F517-3C1A7CCFE662}""
+EndProject
+Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""Nantoka.Shared"", ""Nantoka.Shared.csproj"", ""{CC600BF6-290F-4CF1-A92D-33B3A2B2BB6E}""
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{1E7138DC-D3E2-51A8-4059-67524470B2E7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1E7138DC-D3E2-51A8-4059-67524470B2E7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1E7138DC-D3E2-51A8-4059-67524470B2E7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1E7138DC-D3E2-51A8-4059-67524470B2E7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A94A546A-4413-A73D-F517-3C1A7CCFE662}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A94A546A-4413-A73D-F517-3C1A7CCFE662}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A94A546A-4413-A73D-F517-3C1A7CCFE662}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A94A546A-4413-A73D-F517-3C1A7CCFE662}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CC600BF6-290F-4CF1-A92D-33B3A2B2BB6E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CC600BF6-290F-4CF1-A92D-33B3A2B2BB6E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CC600BF6-290F-4CF1-A92D-33B3A2B2BB6E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CC600BF6-290F-4CF1-A92D-33B3A2B2BB6E}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(MonoDevelopProperties) = preSolution
+		StartupItem = Assembly-CSharp.csproj
+	EndGlobalSection
+EndGlobal
+".Trim());
+            var overlaySln = SolutionFile.Parse(@"C:\Path\To\Nantoka\Nantoka.Server\Nantoka.Server.sln", @"
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29509.3
+MinimumVisualStudioVersion = 10.0.40219.1
+Project(""{9A19103F-16F7-4668-BE54-9A1E7A4F7556}"") = ""Nantoka.Server"", ""Nantoka.Server\Nantoka.Server.csproj"", ""{053476FC-B8B2-4A14-AED2-3733DFD5DFC3}""
+EndProject
+Project(""{9A19103F-16F7-4668-BE54-9A1E7A4F7556}"") = ""Nantoka.Shared"", ""Nantoka.Shared\Nantoka.Shared.csproj"", ""{EC057CB9-6687-4425-82D8-A31A4EE9E4A2}""
+EndProject
+Project(""{2150E333-8FDC-42A3-9474-1A3956D46DE8}"") = ""Project Settings"", ""Project Settings"", ""{34006C71-946B-49BF-BBCB-BB091E5A3AE7}""
+	ProjectSection(SolutionItems) = preProject
+		.gitignore = .gitignore
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{053476FC-B8B2-4A14-AED2-3733DFD5DFC3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{053476FC-B8B2-4A14-AED2-3733DFD5DFC3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{053476FC-B8B2-4A14-AED2-3733DFD5DFC3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{053476FC-B8B2-4A14-AED2-3733DFD5DFC3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EC057CB9-6687-4425-82D8-A31A4EE9E4A2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EC057CB9-6687-4425-82D8-A31A4EE9E4A2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EC057CB9-6687-4425-82D8-A31A4EE9E4A2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EC057CB9-6687-4425-82D8-A31A4EE9E4A2}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {30D3EFC0-A5F4-4446-B14E-1C2C1740AA87}
+	EndGlobalSection
+EndGlobal
+".Trim());
+
+            var mergedSolutionFile = SlnMerge.Merge(baseSln, overlaySln, new SlnMergeSettings() { ProjectConflictResolution = ProjectConflictResolution.PreserveUnity }, SlnMergeNullLogger.Instance);
+            var content = mergedSolutionFile.ToFileContent();
+            Assert.Equal(@"
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 16
+Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""Assembly-CSharp"", ""Assembly-CSharp.csproj"", ""{1E7138DC-D3E2-51A8-4059-67524470B2E7}""
+EndProject
+Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""Assembly-CSharp-Editor"", ""Assembly-CSharp-Editor.csproj"", ""{A94A546A-4413-A73D-F517-3C1A7CCFE662}""
+EndProject
+Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""Nantoka.Shared"", ""Nantoka.Shared.csproj"", ""{CC600BF6-290F-4CF1-A92D-33B3A2B2BB6E}""
+EndProject
+Project(""{9A19103F-16F7-4668-BE54-9A1E7A4F7556}"") = ""Nantoka.Server"", ""..\Nantoka.Server\Nantoka.Server\Nantoka.Server.csproj"", ""{053476FC-B8B2-4A14-AED2-3733DFD5DFC3}""
+EndProject
+Project(""{2150E333-8FDC-42A3-9474-1A3956D46DE8}"") = ""Project Settings"", ""Project Settings"", ""{34006C71-946B-49BF-BBCB-BB091E5A3AE7}""
+	ProjectSection(SolutionItems) = preProject
+		.gitignore = .gitignore
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{1E7138DC-D3E2-51A8-4059-67524470B2E7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1E7138DC-D3E2-51A8-4059-67524470B2E7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1E7138DC-D3E2-51A8-4059-67524470B2E7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1E7138DC-D3E2-51A8-4059-67524470B2E7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A94A546A-4413-A73D-F517-3C1A7CCFE662}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A94A546A-4413-A73D-F517-3C1A7CCFE662}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A94A546A-4413-A73D-F517-3C1A7CCFE662}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A94A546A-4413-A73D-F517-3C1A7CCFE662}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CC600BF6-290F-4CF1-A92D-33B3A2B2BB6E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CC600BF6-290F-4CF1-A92D-33B3A2B2BB6E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CC600BF6-290F-4CF1-A92D-33B3A2B2BB6E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CC600BF6-290F-4CF1-A92D-33B3A2B2BB6E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{053476FC-B8B2-4A14-AED2-3733DFD5DFC3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{053476FC-B8B2-4A14-AED2-3733DFD5DFC3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{053476FC-B8B2-4A14-AED2-3733DFD5DFC3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{053476FC-B8B2-4A14-AED2-3733DFD5DFC3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EC057CB9-6687-4425-82D8-A31A4EE9E4A2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EC057CB9-6687-4425-82D8-A31A4EE9E4A2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EC057CB9-6687-4425-82D8-A31A4EE9E4A2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EC057CB9-6687-4425-82D8-A31A4EE9E4A2}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(MonoDevelopProperties) = preSolution
+		StartupItem = Assembly-CSharp.csproj
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {30D3EFC0-A5F4-4446-B14E-1C2C1740AA87}
+	EndGlobalSection
+EndGlobal
+".Trim(), content.Trim());
+        }
+
+
+        [Fact]
+        public void TestMerge_SameName_PreserveOverlay()
+        {
+            var baseSln = SolutionFile.Parse(@"C:\Path\To\Nantoka\Nantoka.Unity\Nantoka.Unity.sln", @"
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 16
+Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""Assembly-CSharp"", ""Assembly-CSharp.csproj"", ""{1E7138DC-D3E2-51A8-4059-67524470B2E7}""
+EndProject
+Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""Assembly-CSharp-Editor"", ""Assembly-CSharp-Editor.csproj"", ""{A94A546A-4413-A73D-F517-3C1A7CCFE662}""
+EndProject
+Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""Nantoka.Shared"", ""Nantoka.Shared.csproj"", ""{CC600BF6-290F-4CF1-A92D-33B3A2B2BB6E}""
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{1E7138DC-D3E2-51A8-4059-67524470B2E7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1E7138DC-D3E2-51A8-4059-67524470B2E7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1E7138DC-D3E2-51A8-4059-67524470B2E7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1E7138DC-D3E2-51A8-4059-67524470B2E7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A94A546A-4413-A73D-F517-3C1A7CCFE662}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A94A546A-4413-A73D-F517-3C1A7CCFE662}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A94A546A-4413-A73D-F517-3C1A7CCFE662}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A94A546A-4413-A73D-F517-3C1A7CCFE662}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CC600BF6-290F-4CF1-A92D-33B3A2B2BB6E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CC600BF6-290F-4CF1-A92D-33B3A2B2BB6E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CC600BF6-290F-4CF1-A92D-33B3A2B2BB6E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CC600BF6-290F-4CF1-A92D-33B3A2B2BB6E}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(MonoDevelopProperties) = preSolution
+		StartupItem = Assembly-CSharp.csproj
+	EndGlobalSection
+EndGlobal
+".Trim());
+            var overlaySln = SolutionFile.Parse(@"C:\Path\To\Nantoka\Nantoka.Server\Nantoka.Server.sln", @"
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29509.3
+MinimumVisualStudioVersion = 10.0.40219.1
+Project(""{9A19103F-16F7-4668-BE54-9A1E7A4F7556}"") = ""Nantoka.Server"", ""Nantoka.Server\Nantoka.Server.csproj"", ""{053476FC-B8B2-4A14-AED2-3733DFD5DFC3}""
+EndProject
+Project(""{9A19103F-16F7-4668-BE54-9A1E7A4F7556}"") = ""Nantoka.Shared"", ""Nantoka.Shared\Nantoka.Shared.csproj"", ""{EC057CB9-6687-4425-82D8-A31A4EE9E4A2}""
+EndProject
+Project(""{2150E333-8FDC-42A3-9474-1A3956D46DE8}"") = ""Project Settings"", ""Project Settings"", ""{34006C71-946B-49BF-BBCB-BB091E5A3AE7}""
+	ProjectSection(SolutionItems) = preProject
+		.gitignore = .gitignore
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{053476FC-B8B2-4A14-AED2-3733DFD5DFC3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{053476FC-B8B2-4A14-AED2-3733DFD5DFC3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{053476FC-B8B2-4A14-AED2-3733DFD5DFC3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{053476FC-B8B2-4A14-AED2-3733DFD5DFC3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EC057CB9-6687-4425-82D8-A31A4EE9E4A2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EC057CB9-6687-4425-82D8-A31A4EE9E4A2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EC057CB9-6687-4425-82D8-A31A4EE9E4A2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EC057CB9-6687-4425-82D8-A31A4EE9E4A2}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {30D3EFC0-A5F4-4446-B14E-1C2C1740AA87}
+	EndGlobalSection
+EndGlobal
+".Trim());
+
+            var mergedSolutionFile = SlnMerge.Merge(baseSln, overlaySln, new SlnMergeSettings(){ ProjectConflictResolution = ProjectConflictResolution.PreserveOverlay }, SlnMergeNullLogger.Instance);
+            var content = mergedSolutionFile.ToFileContent();
+            Assert.Equal(@"
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 16
+Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""Assembly-CSharp"", ""Assembly-CSharp.csproj"", ""{1E7138DC-D3E2-51A8-4059-67524470B2E7}""
+EndProject
+Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""Assembly-CSharp-Editor"", ""Assembly-CSharp-Editor.csproj"", ""{A94A546A-4413-A73D-F517-3C1A7CCFE662}""
+EndProject
+Project(""{9A19103F-16F7-4668-BE54-9A1E7A4F7556}"") = ""Nantoka.Shared"", ""..\Nantoka.Server\Nantoka.Shared\Nantoka.Shared.csproj"", ""{EC057CB9-6687-4425-82D8-A31A4EE9E4A2}""
+EndProject
+Project(""{9A19103F-16F7-4668-BE54-9A1E7A4F7556}"") = ""Nantoka.Server"", ""..\Nantoka.Server\Nantoka.Server\Nantoka.Server.csproj"", ""{053476FC-B8B2-4A14-AED2-3733DFD5DFC3}""
+EndProject
+Project(""{2150E333-8FDC-42A3-9474-1A3956D46DE8}"") = ""Project Settings"", ""Project Settings"", ""{34006C71-946B-49BF-BBCB-BB091E5A3AE7}""
+	ProjectSection(SolutionItems) = preProject
+		.gitignore = .gitignore
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{1E7138DC-D3E2-51A8-4059-67524470B2E7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1E7138DC-D3E2-51A8-4059-67524470B2E7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1E7138DC-D3E2-51A8-4059-67524470B2E7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1E7138DC-D3E2-51A8-4059-67524470B2E7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A94A546A-4413-A73D-F517-3C1A7CCFE662}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A94A546A-4413-A73D-F517-3C1A7CCFE662}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A94A546A-4413-A73D-F517-3C1A7CCFE662}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A94A546A-4413-A73D-F517-3C1A7CCFE662}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CC600BF6-290F-4CF1-A92D-33B3A2B2BB6E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CC600BF6-290F-4CF1-A92D-33B3A2B2BB6E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CC600BF6-290F-4CF1-A92D-33B3A2B2BB6E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CC600BF6-290F-4CF1-A92D-33B3A2B2BB6E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{053476FC-B8B2-4A14-AED2-3733DFD5DFC3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{053476FC-B8B2-4A14-AED2-3733DFD5DFC3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{053476FC-B8B2-4A14-AED2-3733DFD5DFC3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{053476FC-B8B2-4A14-AED2-3733DFD5DFC3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EC057CB9-6687-4425-82D8-A31A4EE9E4A2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EC057CB9-6687-4425-82D8-A31A4EE9E4A2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EC057CB9-6687-4425-82D8-A31A4EE9E4A2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EC057CB9-6687-4425-82D8-A31A4EE9E4A2}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(MonoDevelopProperties) = preSolution
+		StartupItem = Assembly-CSharp.csproj
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {30D3EFC0-A5F4-4446-B14E-1C2C1740AA87}
+	EndGlobalSection
+EndGlobal
+".Trim(), content.Trim());
+        }
+
     }
 
     class SlnMergeNullLogger : ISlnMergeLogger


### PR DESCRIPTION
This PR fixes #3 

Introduce `ProjectConflictResolution` option.
If the solution contains a project with the same name, you can specify a resolution strategy.

## Options
- `PreserveAll`: Preserve all projects (both Unity generated projects and original projects)
- `PreserveUnity`: Preserve Unity generated projects. (discard original project in a overlay solution)
- `PreserveOverlay`: Preserve original projects in a overlay solution. (discard Unity generated projects from a merged solution)