### PR TITLE
chore: release on workflow_dispatch

### DIFF
--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -7,9 +7,8 @@ on:
     tags:
       - "!*" # not a tag push
   pull_request:
-    types:
-      - opened
-      - synchronize
+    branches:
+      - "master"
 
 jobs:
   build-dotnet:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -26,40 +26,51 @@ jobs:
       sha: ${{ steps.commit.outputs.sha }}
     steps:
       - uses: actions/checkout@v2
-      - name: before
+      - name: Output package.json (Before)
         run: cat ${{ env.TARGET_FILE}}
-      - name: update package.json to version ${{ env.GIT_TAG }}
+
+      - name: Update package.json to version ${{ env.GIT_TAG }}
         run: sed -i -e "s/\(\"version\":\) \"\(.*\)\",/\1 \"${{ env.GIT_TAG }}\",/" ${{ env.TARGET_FILE }}
-      - name: after
-        run: cat ${{ env.TARGET_FILE}}
+
+      - name: Check update
+        id: check_update
+        run: |
+          cat ${{ env.TARGET_FILE}}
+          git diff --exit-code || echo "::set-output name=changed::1"
+
       - name: Commit files
         id: commit
+        if: steps.check_update.outputs.changed == '1'
         run: |
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
           git commit -m "feat: Update package.json to ${{ env.GIT_TAG }}" -a
           echo "::set-output name=sha::$(git rev-parse HEAD)"
-      - name: check sha
+
+      - name: Check sha
         run: echo "SHA ${SHA}"
         env:
           SHA: ${{ steps.commit.outputs.sha }}
-      - name: tag
+
+      - name: Create Tag
+        if: steps.check_update.outputs.changed == '1'
         run: git tag ${{ env.GIT_TAG }}
-        if: env.DRY_RUN == 'false'
+
       - name: Push changes
+        if: env.DRY_RUN == 'false' && steps.check_update.outputs.changed == '1'
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ github.ref }}
           tags: true
-        if: env.DRY_RUN == 'false'
+
       - name: Push changes (dry_run)
+        if: env.DRY_RUN == 'true' && steps.check_update.outputs.changed == '1'
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ env.DRY_RUN_BRANCH_PREFIX }}-${{ env.GIT_TAG }}
           tags: false
-        if: env.DRY_RUN == 'true'
 
   build-dotnet:
     needs: [update-packagejson]

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -12,6 +12,8 @@ on:
         default: "false"
 
 env:
+  GIT_TAG: ${{ github.event.inputs.tag }}
+  DRY_RUN: ${{ github.event.inputs.dry_run }}
   DRY_RUN_BRANCH_PREFIX: "test_release"
   DOTNET_SDK_VERISON_3: 3.1.x
 
@@ -19,9 +21,7 @@ jobs:
   update-packagejson:
     runs-on: ubuntu-latest
     env:
-      GIT_TAG: ${{ github.event.inputs.tag }}
       TARGET_FILE: ./src/package.json
-      DRY_RUN: ${{ github.event.inputs.dry_run }}
     outputs:
       sha: ${{ steps.commit.outputs.sha }}
     steps:
@@ -43,12 +43,15 @@ jobs:
         run: echo "SHA ${SHA}"
         env:
           SHA: ${{ steps.commit.outputs.sha }}
+      - name: tag
+        run: git tag ${{ env.GIT_TAG }}
+        if: env.DRY_RUN == 'false'
       - name: Push changes
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ github.ref }}
-          tags: false
+          tags: true
         if: env.DRY_RUN == 'false'
       - name: Push changes (dry_run)
         uses: ad-m/github-push-action@master
@@ -63,7 +66,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
-      GIT_TAG: ${{ github.event.inputs.tag }}
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
       NUGET_XMLDOC_MODE: skip
@@ -80,10 +82,9 @@ jobs:
 
   create-release:
     if: github.event.inputs.dry_run == 'false'
-    needs: [build-dotnet]
+    needs: [update-packagejson, build-dotnet]
     runs-on: ubuntu-latest
     env:
-      GIT_TAG: ${{ github.event.inputs.tag }}
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
       NUGET_XMLDOC_MODE: skip
@@ -92,21 +93,22 @@ jobs:
       - uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ env.DOTNET_SDK_VERISON_3 }}
-      # Create Releases
+      # Create Release
       - uses: actions/create-release@v1
         id: create_release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Ver.${{ github.ref }}
+          tag_name: ${{ env.GIT_TAG }}
+          release_name: Ver.${{ env.GIT_TAG }}
+          commitish: ${{ needs.update-packagejson.outputs.sha }}
+          draft: true
+          prerelease: false
 
   cleanup:
     if: github.event.inputs.dry_run == 'true'
-    needs: [build-dotnet, build-unity]
+    needs: [build-dotnet]
     runs-on: ubuntu-latest
-    env:
-      GIT_TAG: ${{ github.event.inputs.tag }}
     steps:
       - name: Delete branch
         uses: dawidd6/action-delete-branch@v3

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,14 +1,69 @@
 name: Build-Release
 
 on:
-  push:
-    tags:
-      - "[0-9]+.[0-9]+.[0-9]+*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "tag: git tag you want create. (sample 1.0.0)"
+        required: true
+      dry_run:
+        description: "dry_run: true will never create release/nuget."
+        required: true
+        default: "false"
+
+env:
+  DRY_RUN_BRANCH_PREFIX: "test_release"
+  DOTNET_SDK_VERISON_3: 3.1.x
 
 jobs:
-  build-dotnet:
+  update-packagejson:
     runs-on: ubuntu-latest
     env:
+      GIT_TAG: ${{ github.event.inputs.tag }}
+      TARGET_FILE: ./src/package.json
+      DRY_RUN: ${{ github.event.inputs.dry_run }}
+    outputs:
+      sha: ${{ steps.commit.outputs.sha }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: before
+        run: cat ${{ env.TARGET_FILE}}
+      - name: update package.json to version ${{ env.GIT_TAG }}
+        run: sed -i -e "s/\(\"version\":\) \"\(.*\)\",/\1 \"${{ env.GIT_TAG }}\",/" ${{ env.TARGET_FILE }}
+      - name: after
+        run: cat ${{ env.TARGET_FILE}}
+      - name: Commit files
+        id: commit
+        run: |
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git commit -m "feat: Update package.json to ${{ env.GIT_TAG }}" -a
+          echo "::set-output name=sha::$(git rev-parse HEAD)"
+      - name: check sha
+        run: echo "SHA ${SHA}"
+        env:
+          SHA: ${{ steps.commit.outputs.sha }}
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref }}
+          tags: false
+        if: env.DRY_RUN == 'false'
+      - name: Push changes (dry_run)
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ env.DRY_RUN_BRANCH_PREFIX }}-${{ env.GIT_TAG }}
+          tags: false
+        if: env.DRY_RUN == 'true'
+
+  build-dotnet:
+    needs: [update-packagejson]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      GIT_TAG: ${{ github.event.inputs.tag }}
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
       NUGET_XMLDOC_MODE: skip
@@ -16,10 +71,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.x
-      # set release tag(*.*.*) to env.GIT_TAG
-      - run: echo "GIT_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
-
+          dotnet-version: ${{ env.DOTNET_SDK_VERISON_3 }}
       # pack nuget
       - run: dotnet build -c Release test/SlnMerge.Tests -p:Version=${{ env.GIT_TAG }}
       - run: dotnet test -c Release --no-build test/SlnMerge.Tests -p:Version=${{ env.GIT_TAG }}
@@ -27,9 +79,11 @@ jobs:
       # no unity build
 
   create-release:
-    needs: build-dotnet
+    if: github.event.inputs.dry_run == 'false'
+    needs: [build-dotnet]
     runs-on: ubuntu-latest
     env:
+      GIT_TAG: ${{ github.event.inputs.tag }}
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
       NUGET_XMLDOC_MODE: skip
@@ -37,10 +91,7 @@ jobs:
       # setup dotnet for nuget push
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.x
-      # set release tag(*.*.*) to env.GIT_TAG
-      - run: echo "GIT_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
-
+          dotnet-version: ${{ env.DOTNET_SDK_VERISON_3 }}
       # Create Releases
       - uses: actions/create-release@v1
         id: create_release
@@ -49,3 +100,16 @@ jobs:
         with:
           tag_name: ${{ github.ref }}
           release_name: Ver.${{ github.ref }}
+
+  cleanup:
+    if: github.event.inputs.dry_run == 'true'
+    needs: [build-dotnet, build-unity]
+    runs-on: ubuntu-latest
+    env:
+      GIT_TAG: ${{ github.event.inputs.tag }}
+    steps:
+      - name: Delete branch
+        uses: dawidd6/action-delete-branch@v3
+        with:
+          github_token: ${{ github.token }}
+          branches: ${{ env.DRY_RUN_BRANCH_PREFIX }}-${{ env.GIT_TAG }}


### PR DESCRIPTION
## TL;DR

* Change release flow from `tag push` to `worlkflow dispatch`.This enable `dry_run` to create package before tag/release.
* debug build on `master` branch push/pr only.

## Change

* before: tag version `1.0.0` and push to origin will start release github actions.
* after: go to github actions -> build-release -> Workflow dispatch -> set `tag` & `dry_run`.
